### PR TITLE
fix: move to to_atom for weight unit enum

### DIFF
--- a/lib/library_support/ecto.ex
+++ b/lib/library_support/ecto.ex
@@ -76,7 +76,7 @@ if Code.ensure_loaded?(Ecto.Type) do
     @spec load(map()) :: {:ok, Massex.t()}
     def load(%{"amount" => amount, "unit" => unit})
         when is_integer(amount) or is_binary(amount) do
-      {:ok, Massex.new(amount, String.to_existing_atom(unit))}
+      {:ok, Massex.new(amount, String.to_atom(unit))}
     end
   end
 end

--- a/lib/massex.ex
+++ b/lib/massex.ex
@@ -234,7 +234,7 @@ defmodule Massex do
   defp standardize_unit(:ounce), do: {:ok, :ounce}
 
   defp standardize_unit(unit) when is_binary(unit),
-    do: unit |> String.to_existing_atom() |> standardize_unit()
+    do: unit |> String.to_atom() |> standardize_unit()
 
   defp standardize_unit(_), do: :error
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Massex.MixProject do
   use Mix.Project
 
-  @version "0.1.1"
+  @version "0.1.2"
   @description "A whole-value pattern library for handling masses"
   @homepage_url "https://github.com/venndr/massex"
 


### PR DESCRIPTION
`to_existing_atom` is causing us a lot of problems in testing and in seeding and not giving us very much value.

Read here for example: https://nietaki.com/2018/12/04/string-to-existing-atom-is-a-double-edged-sword/

We are already testing all ingress points using GRAPHQL enums and joi validations so I think we can allow ourselves to not be so strict about the atom here.